### PR TITLE
add support for description_hash in createInvoice and createHodlInvoice

### DIFF
--- a/lnd_methods/invoices/create_hodl_invoice.js
+++ b/lnd_methods/invoices/create_hodl_invoice.js
@@ -17,6 +17,7 @@ const {parse} = Date;
 const preimageByteLength = 32;
 const {round} = Math;
 const sha256 = preimage => createHash('sha256').update(preimage).digest();
+const hexAsBuffer = hex => !!hex ? Buffer.from(hex, 'hex') : undefined;
 const tokensAsMtok = tokens => (BigInt(tokens) * BigInt(1e3)).toString();
 const type = 'invoices';
 
@@ -34,6 +35,7 @@ const type = 'invoices';
   {
     [cltv_delta]: <Final CLTV Delta Number>
     [description]: <Invoice Description String>
+    [description_hash]: <Hashed Description of Payment Hex String>
     [expires_at]: <Expires At ISO 8601 Date String>
     [id]: <Payment Hash Hex String>
     [is_fallback_included]: <Is Fallback Address Included Bool>
@@ -118,6 +120,7 @@ module.exports = (args, cbk) => {
           private: !!args.is_including_private_channels,
           value: args.tokens || undefined,
           value_msat: args.mtokens || undefined,
+          description_hash: hexAsBuffer(args.description_hash),
         },
         (err, response) => {
           if (!!err) {

--- a/lnd_methods/invoices/create_invoice.js
+++ b/lnd_methods/invoices/create_invoice.js
@@ -10,6 +10,7 @@ const defaultExpiryMs = 1000 * 60 * 60 * 3;
 const invoiceExistsError = 'invoice with payment hash already exists';
 const {isArray} = Array;
 const isHex = n => !(n.length % 2) && /^[0-9A-F]*$/i.test(n);
+const hexAsBuffer = hex => !!hex ? Buffer.from(hex, 'hex') : undefined;
 const msPerSec = 1e3;
 const {parse} = Date;
 const {round} = Math;
@@ -21,6 +22,7 @@ const {round} = Math;
   {
     [cltv_delta]: <CLTV Delta Number>
     [description]: <Invoice Description String>
+    [description_hash]: <Hashed Description of Payment Hex String>
     [expires_at]: <Expires At ISO 8601 Date String>
     [is_fallback_included]: <Is Fallback Address Included Bool>
     [is_fallback_nested]: <Is Fallback Address Nested Bool>
@@ -99,6 +101,7 @@ module.exports = (args, cbk) => {
           private: !!args.is_including_private_channels,
           r_preimage: preimage || undefined,
           value: args.tokens || undefined,
+          description_hash: hexAsBuffer(args.description_hash),
         },
         (err, response) => {
           if (!!err && err.details === invoiceExistsError) {


### PR DESCRIPTION
Hey!
This PR adds `description_hash` (BOLT 11 tag `h`) support to the `createInvoice` and `createHodlInvoice` functions

Functionality has been tested together with [ln-service](https://github.com/alexbosworth/ln-service).