### PR TITLE
Add lnd_methods/peers types

### DIFF
--- a/lnd_methods/index.d.ts
+++ b/lnd_methods/index.d.ts
@@ -1,0 +1,1 @@
+export * from './peers';

--- a/lnd_methods/peers/add_peer.d.ts
+++ b/lnd_methods/peers/add_peer.d.ts
@@ -1,0 +1,25 @@
+import {AuthenticatedLndMethod} from '../../typescript/shared';
+
+export type AddPeerArgs = {
+  /** Add Peer as Temporary Peer, default: `false` */
+  is_temporary?: boolean;
+  /** Public Key Hex */
+  public_key: string;
+  /** Retry Count */
+  retry_count?: number;
+  /** Delay Retry By Milliseconds */
+  retry_delay?: number;
+  /** Host Network Address And Optional Port, format: ip:port */
+  socket: string;
+  /** Connection Attempt Timeout Milliseconds, not supported in LND 0.11.1 and below */
+  timeout?: number;
+};
+
+/**
+ * Add a peer if possible (not self, or already connected)
+ *
+ * Requires `peers:write` permission
+ *
+ * `timeout` is not supported in LND 0.11.1 and below
+ */
+export const addPeer: AuthenticatedLndMethod<AddPeerArgs>;

--- a/lnd_methods/peers/get_peers.d.ts
+++ b/lnd_methods/peers/get_peers.d.ts
@@ -1,0 +1,47 @@
+import {AuthenticatedLndMethod} from '../../typescript/shared';
+
+export type GetPeersResult = {
+  peers: {
+    /** Bytes Received */
+    bytes_received: number;
+    /** Bytes Sent */
+    bytes_sent: number;
+    features: {
+      /** BOLT 09 Feature Bit */
+      bit: number;
+      /** Feature is Known */
+      is_known: boolean;
+      /** Feature Support is Required */
+      is_required: boolean;
+      /** Feature Type */
+      type: string;
+    }[];
+    /** Is Inbound Peer */
+    is_inbound: boolean;
+    /** Is Syncing Graph Data */
+    is_sync_peer?: boolean;
+    /** Peer Last Reconnected At ISO 8601 Date */
+    last_reconnected?: string;
+    /** Ping Latency Milliseconds */
+    ping_time: number;
+    /** Node Identity Public Key */
+    public_key: string;
+    /** Count of Reconnections Over Time */
+    reconnection_rate?: number;
+    /** Network Address And Port */
+    socket: string;
+    /** Amount Received Tokens */
+    tokens_received: number;
+    /** Amount Sent Tokens */
+    tokens_sent: number;
+  }[];
+};
+
+/**
+ * Get connected peers.
+ *
+ * Requires `peers:read` permission
+ *
+ * LND 0.11.1 and below do not return `last_reconnected` or `reconnection_rate
+ */
+export const getPeers: AuthenticatedLndMethod<{}, GetPeersResult>;

--- a/lnd_methods/peers/index.d.ts
+++ b/lnd_methods/peers/index.d.ts
@@ -1,1 +1,2 @@
 export * from './add_peer';
+export * from './get_peers';

--- a/lnd_methods/peers/index.d.ts
+++ b/lnd_methods/peers/index.d.ts
@@ -1,0 +1,1 @@
+export * from './add_peer';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning",
-  "version": "3.0.16",
+  "version": "3.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -131,6 +131,13 @@
         "@types/node": "^12.12.47",
         "google-auth-library": "^6.1.1",
         "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.19.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
+          "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw=="
+        }
       }
     },
     "@grpc/proto-loader": {
@@ -297,9 +304,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
-      "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg=="
+      "version": "14.14.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -5645,12 +5652,6 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
-    },
-    "typescript": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
-      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
-      "dev": true
     },
     "unicode-length": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@grpc/grpc-js": "1.2.2",
     "@grpc/proto-loader": "0.5.5",
     "@types/express": "^4.17.9",
+    "@types/node": "^14.14.20",
     "@types/request": "^2.48.5",
     "@types/ws": "^7.4.0",
     "async": "3.2.0",

--- a/test/typescript/add_peer.test-d.ts
+++ b/test/typescript/add_peer.test-d.ts
@@ -1,0 +1,14 @@
+import {expectError, expectType} from 'tsd';
+import {addPeer} from '../../lnd_methods';
+import {AuthenticatedLnd} from '../../typescript/authenticated_lnd_grpc';
+
+const lnd = {} as AuthenticatedLnd;
+const public_key = Buffer.alloc(33).toString('hex');
+const socket = 'socket';
+
+expectError(addPeer({}));
+expectError(addPeer({lnd}));
+expectError(addPeer({lnd, public_key}));
+expectError(addPeer({lnd, socket}));
+expectType<void>(await addPeer({lnd, public_key, socket}));
+expectType<void>(addPeer({lnd, public_key, socket}, error => {}));

--- a/test/typescript/add_peer.test-d.ts
+++ b/test/typescript/add_peer.test-d.ts
@@ -6,6 +6,7 @@ const lnd = {} as AuthenticatedLnd;
 const public_key = Buffer.alloc(33).toString('hex');
 const socket = 'socket';
 
+expectError(addPeer());
 expectError(addPeer({}));
 expectError(addPeer({lnd}));
 expectError(addPeer({lnd, public_key}));

--- a/test/typescript/get_peers.test-d.ts
+++ b/test/typescript/get_peers.test-d.ts
@@ -1,0 +1,14 @@
+import {expectError, expectType} from 'tsd';
+import {getPeers, GetPeersResult} from '../../lnd_methods';
+import {AuthenticatedLnd} from '../../typescript/authenticated_lnd_grpc';
+
+const lnd = {} as AuthenticatedLnd;
+
+expectError(getPeers());
+expectError(getPeers({}));
+expectType<GetPeersResult>(await getPeers({lnd}));
+expectType<void>(
+  getPeers({lnd}, (error, result) => {
+    expectType<GetPeersResult>(result);
+  })
+);

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -2,4 +2,5 @@ export * from './authenticated_lnd_grpc';
 export * from './emit_grpc_events';
 export * from './grpc_router';
 export * from './lnd_gateway';
+export * from './shared';
 export * from './unauthenticated_lnd_grpc';

--- a/typescript/shared.d.ts
+++ b/typescript/shared.d.ts
@@ -1,0 +1,35 @@
+import * as events from 'events';
+import {AuthenticatedLnd} from './authenticated_lnd_grpc';
+import {UnauthenticatedLnd} from './unauthenticated_lnd_grpc';
+
+export type LightningError<TDetails = any> = [number, string, TDetails];
+
+export type LightningCallback<TResult = void, TErrorDetails = any> = (
+  error: LightningError<TErrorDetails> | undefined | null,
+  result: TResult extends void ? undefined : TResult
+) => void;
+
+export type LightningMethod<
+  TArgs = {[key: string]: never},
+  TResult = void,
+  TErrorDetails = any
+> = {
+  (args: TArgs): Promise<TResult>;
+  (args: TArgs, callback: LightningCallback<TResult, TErrorDetails>): void;
+};
+
+export type AuthenticatedLndMethod<
+  TArgs = {[key: string]: never},
+  TResult = void,
+  TErrorDetails = any
+> = LightningMethod<TArgs & {lnd: AuthenticatedLnd}, TResult, TErrorDetails>;
+
+export type UnauthenticatedLndMethod<
+  TArgs = {[key: string]: never},
+  TResult = void,
+  TErrorDetails = any
+> = LightningMethod<TArgs & {lnd: UnauthenticatedLnd}, TResult, TErrorDetails>;
+
+export type AuthenticatedLndSubscription<TArgs = {[key: string]: never}> = (
+  args: TArgs & {lnd: AuthenticatedLnd}
+) => events.EventEmitter;


### PR DESCRIPTION
I started adding types for lnd_methods

I noticed most of the functions are not exported from the `index.js` so I created the type definitions next to the JS source code because it is more convenient. I think the `typescript` directory's content could also be moved next to their source code, so the typescript exports match the JS exports.

What do you think?
