### PR TITLE
Refactor argument types encapsulation

### DIFF
--- a/lnd_methods/invoices/cancel_hodl_invoice.d.ts
+++ b/lnd_methods/invoices/cancel_hodl_invoice.d.ts
@@ -1,9 +1,12 @@
-import {AuthenticatedLndMethod} from '../../typescript';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
 
-export type CancelHodlInvoiceArgs = {
+export type CancelHodlInvoiceArgs = AuthenticatedLightningArgs<{
   /** Payment Preimage Hash Hex String */
   id: string;
-};
+}>;
 
 /**
  * Cancel an invoice
@@ -14,4 +17,4 @@ export type CancelHodlInvoiceArgs = {
  *
  * Requires `invoices:write` permission
  */
-export const cancelHodlInvoice: AuthenticatedLndMethod<CancelHodlInvoiceArgs>;
+export const cancelHodlInvoice: AuthenticatedLightningMethod<CancelHodlInvoiceArgs>;

--- a/lnd_methods/invoices/create_hodl_invoice.d.ts
+++ b/lnd_methods/invoices/create_hodl_invoice.d.ts
@@ -1,6 +1,9 @@
-import {AuthenticatedLndMethod} from '../../typescript';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
 
-export type CreateHodlInvoiceArgs = {
+export type CreateHodlInvoiceArgs = AuthenticatedLightningArgs<{
   /** Final CLTV Delta */
   cltv_delta?: number;
   /** Invoice Description */
@@ -21,7 +24,7 @@ export type CreateHodlInvoiceArgs = {
   mtokens?: string;
   /** Tokens */
   tokens?: number;
-};
+}>;
 
 export type CreateHodlInvoiceResult = {
   /** Backup Address String */
@@ -51,7 +54,7 @@ export type CreateHodlInvoiceResult = {
  *
  * Requires `address:write`, `invoices:write` permission
  */
-export const createHodlInvoice: AuthenticatedLndMethod<
+export const createHodlInvoice: AuthenticatedLightningMethod<
   CreateHodlInvoiceArgs,
   CreateHodlInvoiceResult
 >;

--- a/lnd_methods/invoices/create_invoice.d.ts
+++ b/lnd_methods/invoices/create_invoice.d.ts
@@ -1,6 +1,9 @@
-import {AuthenticatedLndMethod} from '../../typescript';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
 
-export type CreateInvoiceArgs = {
+export type CreateInvoiceArgs = AuthenticatedLightningArgs<{
   /** CLTV Delta */
   cltv_delta?: number;
   /** Invoice Description */
@@ -21,7 +24,7 @@ export type CreateInvoiceArgs = {
   mtokens?: string;
   /** Tokens */
   tokens?: number;
-};
+}>;
 
 export type CreateInvoiceResult = {
   /** Backup Address */
@@ -55,7 +58,7 @@ export type CreateInvoiceResult = {
  *
  * `payment` is not supported on LND 0.11.1 and below
  */
-export const createInvoice: AuthenticatedLndMethod<
+export const createInvoice: AuthenticatedLightningMethod<
   CreateInvoiceArgs,
   CreateInvoiceResult
 >;

--- a/lnd_methods/invoices/get_invoice.d.ts
+++ b/lnd_methods/invoices/get_invoice.d.ts
@@ -1,9 +1,12 @@
-import {AuthenticatedLndMethod} from '../../typescript';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
 
-export type GetInvoiceArgs = {
+export type GetInvoiceArgs = AuthenticatedLightningArgs<{
   /** Payment Hash Id Hex String */
   id: string;
-};
+}>;
 
 export type GetInvoiceResult = {
   /** Fallback Chain Address */
@@ -98,7 +101,7 @@ over-paid.
  * 
  * `payment` is not supported on LND 0.11.1 and below
  */
-export const getInvoice: AuthenticatedLndMethod<
+export const getInvoice: AuthenticatedLightningMethod<
   GetInvoiceArgs,
   GetInvoiceResult
 >;

--- a/lnd_methods/invoices/get_invoices.d.ts
+++ b/lnd_methods/invoices/get_invoices.d.ts
@@ -1,6 +1,9 @@
-import {AuthenticatedLndMethod} from '../../typescript';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
 
-export type GetInvoicesArgs =
+export type GetInvoicesArgs = AuthenticatedLightningArgs<
   | {
       /** Page Result Limit */
       limit?: number;
@@ -10,7 +13,8 @@ export type GetInvoicesArgs =
       limit?: never;
       /** Opaque Paging Token */
       token?: string;
-    };
+    }
+>;
 
 export type GetInvoicesResult = {
   invoices: {
@@ -104,7 +108,7 @@ export type GetInvoicesResult = {
  *
  * Invoice `payment` is not supported on LND 0.11.1 and below
  */
-export const getInvoices: AuthenticatedLndMethod<
+export const getInvoices: AuthenticatedLightningMethod<
   GetInvoicesArgs,
   GetInvoicesResult
 >;

--- a/lnd_methods/invoices/settle_hodl_invoice.d.ts
+++ b/lnd_methods/invoices/settle_hodl_invoice.d.ts
@@ -1,9 +1,12 @@
-import {AuthenticatedLndMethod} from '../../typescript';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
 
-export type SettleHodlInvoiceArgs = {
+export type SettleHodlInvoiceArgs = AuthenticatedLightningArgs<{
   /** Payment Preimage Hex String */
   secret: string;
-};
+}>;
 
 /**
  * Settle HODL invoice
@@ -12,4 +15,4 @@ export type SettleHodlInvoiceArgs = {
  *
  * Requires `invoices:write` permission
  */
-export const settleHodlInvoice: AuthenticatedLndMethod<SettleHodlInvoiceArgs>;
+export const settleHodlInvoice: AuthenticatedLightningMethod<SettleHodlInvoiceArgs>;

--- a/lnd_methods/invoices/subscribe_to_invoice.d.ts
+++ b/lnd_methods/invoices/subscribe_to_invoice.d.ts
@@ -1,9 +1,12 @@
-import {AuthenticatedLndSubscription} from '../../typescript';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningSubscription,
+} from '../../typescript';
 
-export type SubscribeToInvoiceArgs = {
+export type SubscribeToInvoiceArgs = AuthenticatedLightningArgs<{
   /** Invoice Payment Hash Hex String */
   id: string;
-};
+}>;
 
 export type SubscribeToInvoiceInvoiceUpdatedEvent = {
   /** Fallback Chain Address */
@@ -109,4 +112,4 @@ export type SubscribeToInvoiceInvoiceUpdatedEvent = {
  *
  * `payment` is not supported on LND 0.11.1 and below
  */
-export const subscribeToInvoice: AuthenticatedLndSubscription<SubscribeToInvoiceArgs>;
+export const subscribeToInvoice: AuthenticatedLightningSubscription<SubscribeToInvoiceArgs>;

--- a/lnd_methods/invoices/subscribe_to_invoices.d.ts
+++ b/lnd_methods/invoices/subscribe_to_invoices.d.ts
@@ -1,4 +1,4 @@
-import {AuthenticatedLndSubscription} from '../../typescript';
+import {AuthenticatedLightningSubscription} from '../../typescript';
 
 export type SubscribeToInvoicesInvoiceUpdatedEvent = {
   /** Fallback Chain Address */
@@ -88,4 +88,4 @@ export type SubscribeToInvoicesInvoiceUpdatedEvent = {
  *
  * `payment` is not supported on LND 0.11.1 and below
  */
-export const subscribeToInvoices: AuthenticatedLndSubscription<{}>;
+export const subscribeToInvoices: AuthenticatedLightningSubscription;

--- a/lnd_methods/peers/add_peer.d.ts
+++ b/lnd_methods/peers/add_peer.d.ts
@@ -1,6 +1,9 @@
-import {AuthenticatedLndMethod} from '../../typescript/shared';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript/shared';
 
-export type AddPeerArgs = {
+export type AddPeerArgs = AuthenticatedLightningArgs<{
   /** Add Peer as Temporary Peer, default: `false` */
   is_temporary?: boolean;
   /** Public Key Hex */
@@ -13,7 +16,7 @@ export type AddPeerArgs = {
   socket: string;
   /** Connection Attempt Timeout Milliseconds, not supported in LND 0.11.1 and below */
   timeout?: number;
-};
+}>;
 
 /**
  * Add a peer if possible (not self, or already connected)
@@ -22,4 +25,4 @@ export type AddPeerArgs = {
  *
  * `timeout` is not supported in LND 0.11.1 and below
  */
-export const addPeer: AuthenticatedLndMethod<AddPeerArgs>;
+export const addPeer: AuthenticatedLightningMethod<AddPeerArgs>;

--- a/lnd_methods/peers/get_peers.d.ts
+++ b/lnd_methods/peers/get_peers.d.ts
@@ -1,4 +1,5 @@
-import {AuthenticatedLndMethod} from '../../typescript/shared';
+import {AuthenticatedLnd} from '../../lnd_grpc';
+import {AuthenticatedLightningMethod} from '../../typescript/shared';
 
 export type GetPeersResult = {
   peers: {
@@ -44,4 +45,7 @@ export type GetPeersResult = {
  *
  * LND 0.11.1 and below do not return `last_reconnected` or `reconnection_rate
  */
-export const getPeers: AuthenticatedLndMethod<{}, GetPeersResult>;
+export const getPeers: AuthenticatedLightningMethod<
+  {lnd: AuthenticatedLnd},
+  GetPeersResult
+>;

--- a/lnd_methods/peers/remove_peer.d.ts
+++ b/lnd_methods/peers/remove_peer.d.ts
@@ -1,13 +1,16 @@
-import {AuthenticatedLndMethod} from '../../typescript/shared';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript/shared';
 
-export type RemovePeerArgs = {
+export type RemovePeerArgs = AuthenticatedLightningArgs<{
   /** Public Key Hex */
   public_key: string;
-};
+}>;
 
 /**
  * Remove a peer if possible
  *
  * Requires `peers:remove` permission
  */
-export const removePeer: AuthenticatedLndMethod<RemovePeerArgs>;
+export const removePeer: AuthenticatedLightningMethod<RemovePeerArgs>;

--- a/lnd_methods/signer/diffie_hellman_compute_secret.d.ts
+++ b/lnd_methods/signer/diffie_hellman_compute_secret.d.ts
@@ -1,13 +1,16 @@
-import {AuthenticatedLndMethod} from '../../typescript';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
 
-export type DiffieHellmanComputeSecretArgs = {
+export type DiffieHellmanComputeSecretArgs = AuthenticatedLightningArgs<{
   /** Key Family */
   key_family?: number;
   /** Key Index */
   key_index?: number;
   /** Public Key Hex */
   partner_public_key: string;
-};
+}>;
 
 export type DiffieHellmanComputeSecretResult = {
   /** Shared Secret Hex */
@@ -23,7 +26,7 @@ export type DiffieHellmanComputeSecretResult = {
  *
  * Requires `signer:generate` permission
  */
-export const diffieHellmanComputeSecret: AuthenticatedLndMethod<
+export const diffieHellmanComputeSecret: AuthenticatedLightningMethod<
   DiffieHellmanComputeSecretArgs,
   DiffieHellmanComputeSecretResult
 >;

--- a/lnd_methods/signer/sign_bytes.d.ts
+++ b/lnd_methods/signer/sign_bytes.d.ts
@@ -1,13 +1,16 @@
-import {AuthenticatedLndMethod} from '../../typescript';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
 
-export type SignBytesArgs = {
+export type SignBytesArgs = AuthenticatedLightningArgs<{
   /** Key Family */
   key_family: number;
   /** Key Index */
   key_index: number;
   /** Bytes To Hash and Sign Hex Encoded String */
   preimage: string;
-};
+}>;
 
 export type SignBytesResult = {
   /** Signature Hex String */
@@ -21,4 +24,7 @@ export type SignBytesResult = {
  *
  * Requires `signer:generate` permission
  */
-export const signBytes: AuthenticatedLndMethod<SignBytesArgs, SignBytesResult>;
+export const signBytes: AuthenticatedLightningMethod<
+  SignBytesArgs,
+  SignBytesResult
+>;

--- a/lnd_methods/signer/sign_transaction.d.ts
+++ b/lnd_methods/signer/sign_transaction.d.ts
@@ -1,6 +1,9 @@
-import {AuthenticatedLndMethod} from '../../typescript';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
 
-export type SignTransactionArgs = {
+export type SignTransactionArgs = AuthenticatedLightningArgs<{
   inputs: {
     /** Key Family */
     key_family: number;
@@ -19,7 +22,7 @@ export type SignTransactionArgs = {
   }[];
   /** Unsigned Transaction Hex String */
   transaction: string;
-};
+}>;
 
 export type SignTransactionResult = {
   /** Signature Hex Strings */
@@ -33,7 +36,7 @@ export type SignTransactionResult = {
  *
  * Requires `signer:generate` permission
  */
-export const signTransaction: AuthenticatedLndMethod<
+export const signTransaction: AuthenticatedLightningMethod<
   SignTransactionArgs,
   SignTransactionResult
 >;

--- a/lnd_methods/signer/verify_bytes_signature.d.ts
+++ b/lnd_methods/signer/verify_bytes_signature.d.ts
@@ -1,13 +1,16 @@
-import {AuthenticatedLndMethod} from '../../typescript';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
 
-export type VerifyBytesSignatureArgs = {
+export type VerifyBytesSignatureArgs = AuthenticatedLightningArgs<{
   /** Message Preimage Bytes Hex Encoded String */
   preimage: string;
   /** Signature Valid For Public Key Hex String */
   public_key: string;
   /** Signature Hex */
   signature: string;
-};
+}>;
 
 export type VerifyBytesSignatureResult = {
   /** Signature is Valid */
@@ -21,7 +24,7 @@ export type VerifyBytesSignatureResult = {
  *
  * Requires `signer:read` permission
  */
-export const verifyBytesSignature: AuthenticatedLndMethod<
+export const verifyBytesSignature: AuthenticatedLightningMethod<
   VerifyBytesSignatureArgs,
   VerifyBytesSignatureResult
 >;

--- a/typescript/shared.d.ts
+++ b/typescript/shared.d.ts
@@ -1,6 +1,11 @@
 import * as events from 'events';
 import {AuthenticatedLnd, UnauthenticatedLnd} from '../lnd_grpc';
 
+export type AuthenticatedLightningArgs<TArgs> = TArgs & {lnd: AuthenticatedLnd};
+export type UnauthenticatedLightningArgs<TArgs> = TArgs & {
+  lnd: UnauthenticatedLnd;
+};
+
 export type LightningError<TDetails = any> = [number, string, TDetails];
 
 export type LightningCallback<TResult = void, TErrorDetails = any> = (
@@ -17,18 +22,18 @@ export type LightningMethod<
   (args: TArgs, callback: LightningCallback<TResult, TErrorDetails>): void;
 };
 
-export type AuthenticatedLndMethod<
-  TArgs = {[key: string]: never},
+export type AuthenticatedLightningMethod<
+  TArgs extends {lnd: AuthenticatedLnd} = {lnd: AuthenticatedLnd},
   TResult = void,
   TErrorDetails = any
-> = LightningMethod<TArgs & {lnd: AuthenticatedLnd}, TResult, TErrorDetails>;
+> = LightningMethod<TArgs, TResult, TErrorDetails>;
 
-export type UnauthenticatedLndMethod<
-  TArgs = {[key: string]: never},
+export type UnauthenticatedLightningMethod<
+  TArgs extends {lnd: UnauthenticatedLnd} = {lnd: UnauthenticatedLnd},
   TResult = void,
   TErrorDetails = any
-> = LightningMethod<TArgs & {lnd: UnauthenticatedLnd}, TResult, TErrorDetails>;
+> = LightningMethod<TArgs, TResult, TErrorDetails>;
 
-export type AuthenticatedLndSubscription<TArgs = {[key: string]: never}> = (
-  args: TArgs & {lnd: AuthenticatedLnd}
-) => events.EventEmitter;
+export type AuthenticatedLightningSubscription<
+  TArgs extends {lnd: AuthenticatedLnd} = {lnd: AuthenticatedLnd}
+> = (args: TArgs) => events.EventEmitter;


### PR DESCRIPTION
I changed the authenticated and unauthenticated lightning methods to require the extension of an authenticated or unauthenticated lnd object rather than extending them automatically.

I think it better encapsulates how the method args are used because now the imported `AddPeerArgs` contains the `{lnd: AuthenticatedLnd}` and it's not attached to the args inside the `AuthenticatedLndMethod` function definition. I believe the prior arg types could have been confusing because it's not clear why the `AddPeerArgs` type has no `lnd` object while the related `addPeer` method needs one to work.

This change also means that the `{}` type is no longer needed for several methods. The type `{}` doesn't mean "empty object" in TypeScript so this also reduces confusing types.