### PR TITLE
Add send message types

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ const {recoverFundsFromChannels} = require('./lnd_methods');
 const {removePeer} = require('./lnd_methods');
 const {requestChainFeeIncrease} = require('./lnd_methods');
 const {revokeAccess} = require('./lnd_methods');
+const {sendMessageToPeer} = require('./lnd_methods');
 const {sendToChainAddress} = require('./lnd_methods');
 const {sendToChainAddresses} = require('./lnd_methods');
 const {sendToChainOutputScripts} = require('./lnd_methods');
@@ -221,6 +222,7 @@ module.exports = {
   removePeer,
   requestChainFeeIncrease,
   revokeAccess,
+  sendMessageToPeer,
   sendToChainAddress,
   sendToChainAddresses,
   sendToChainOutputScripts,

--- a/index.js
+++ b/index.js
@@ -114,6 +114,7 @@ const {subscribeToPastPayments} = require('./lnd_methods');
 const {subscribeToPayViaDetails} = require('./lnd_methods');
 const {subscribeToPayViaRequest} = require('./lnd_methods');
 const {subscribeToPayViaRoutes} = require('./lnd_methods');
+const {subscribeToPeerMessages} = require('./lnd_methods');
 const {subscribeToPeers} = require('./lnd_methods');
 const {subscribeToProbeForRoute} = require('./lnd_methods');
 const {subscribeToRpcRequests} = require('./lnd_methods');
@@ -249,6 +250,7 @@ module.exports = {
   subscribeToPayViaDetails,
   subscribeToPayViaRequest,
   subscribeToPayViaRoutes,
+  subscribeToPeerMessages,
   subscribeToPeers,
   subscribeToProbeForRoute,
   subscribeToRpcRequests,

--- a/lnd_methods/offchain/index.d.ts
+++ b/lnd_methods/offchain/index.d.ts
@@ -43,6 +43,7 @@ export * from './subscribe_to_past_payments';
 export * from './subscribe_to_pay_via_details';
 export * from './subscribe_to_pay_via_request';
 export * from './subscribe_to_pay_via_routes';
+export * from './subscribe_to_peer_messages';
 export * from './subscribe_to_probe_for_route';
 export * from './update_connected_watchtower';
 export * from './update_pathfinding_settings';

--- a/lnd_methods/offchain/index.d.ts
+++ b/lnd_methods/offchain/index.d.ts
@@ -32,6 +32,7 @@ export * from './pay';
 export * from './probe_for_route';
 export * from './recover_funds_from_channel';
 export * from './recover_funds_from_channels';
+export * from './send_message_to_peer';
 export * from './subscribe_to_backups';
 export * from './subscribe_to_channels';
 export * from './subscribe_to_forward_requests';

--- a/lnd_methods/offchain/send_message_to_peer.d.ts
+++ b/lnd_methods/offchain/send_message_to_peer.d.ts
@@ -3,14 +3,17 @@ import {
   AuthenticatedLightningMethod,
 } from '../../typescript';
 
-export type SendMessageToPeerArgs = AuthenticatedLightningArgs<{
+export type LightningMessage = {
   /** Message Hex String */
   message: string;
   /** To Peer Public Key Hex String */
   public_key: string;
   /** Message Type Number */
   type?: number;
-}>;
+};
+
+export type SendMessageToPeerArgs =
+  AuthenticatedLightningArgs<LightningMessage>;
 
 /**
  * Send a custom message to a connected peer

--- a/lnd_methods/offchain/send_message_to_peer.d.ts
+++ b/lnd_methods/offchain/send_message_to_peer.d.ts
@@ -1,0 +1,25 @@
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
+
+export type SendMessageToPeerArgs = AuthenticatedLightningArgs<{
+  /** Message Hex String */
+  message: string;
+  /** To Peer Public Key Hex String */
+  public_key: string;
+  /** Message Type Number */
+  type?: number;
+}>;
+
+/**
+ * Send a custom message to a connected peer
+ *
+ * If specified, message type is expected to be between 32768 and 65535
+ * Message data should not be larger than 65533 bytes
+ *
+ * Note: this method is not supported in LND versions 0.13.3 and below
+ *
+ * Requires `offchain:write` permission
+ */
+export const sendMessageToPeer: AuthenticatedLightningMethod<SendMessageToPeerArgs>;

--- a/lnd_methods/offchain/subscribe_to_peer_messages.d.ts
+++ b/lnd_methods/offchain/subscribe_to_peer_messages.d.ts
@@ -1,0 +1,18 @@
+import {LightningMessage} from '.';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningSubscription,
+  LightningError,
+} from '../../typescript';
+
+export type SubscribeToPeerMessagesMessageReceivedEvent =
+  Required<LightningMessage>;
+
+/**
+ * Subscribe to incoming peer messages
+ *
+ * Requires `offchain:read` permission
+ *
+ * This method is not supported in LND 0.13.3 and below
+ */
+export const subscribeToPeerMessages: AuthenticatedLightningSubscription;

--- a/test/typescript/send_message_to_peer.test-d.ts
+++ b/test/typescript/send_message_to_peer.test-d.ts
@@ -1,0 +1,24 @@
+import {expectError, expectType} from 'tsd';
+import {AuthenticatedLnd} from '../../lnd_grpc';
+import {sendMessageToPeer} from '../../lnd_methods';
+
+const lnd = {} as AuthenticatedLnd;
+const message = 'msg';
+const public_key = 'pubkey';
+const type = 2;
+
+expectError(sendMessageToPeer());
+expectError(sendMessageToPeer({}));
+expectError(sendMessageToPeer({lnd}));
+expectError(sendMessageToPeer({lnd, message}));
+expectError(sendMessageToPeer({lnd, public_key}));
+
+expectType<void>(await sendMessageToPeer({lnd, message, public_key}));
+expectType<void>(await sendMessageToPeer({lnd, message, public_key, type}));
+
+expectType<void>(
+  sendMessageToPeer({lnd, message, public_key}, (error, result) => {})
+);
+expectType<void>(
+  sendMessageToPeer({lnd, message, public_key, type}, (error, result) => {})
+);

--- a/test/typescript/subscribe_to_peer_messages.test-d.ts
+++ b/test/typescript/subscribe_to_peer_messages.test-d.ts
@@ -1,0 +1,11 @@
+import * as events from 'events';
+import {expectError, expectType} from 'tsd';
+import {AuthenticatedLnd} from '../../lnd_grpc';
+import {subscribeToPeerMessages} from '../../lnd_methods';
+
+const lnd = {} as AuthenticatedLnd;
+
+expectError(subscribeToPeerMessages());
+expectError(subscribeToPeerMessages({}));
+
+expectType<events.EventEmitter>(subscribeToPeerMessages({lnd}));


### PR DESCRIPTION
I added the types for the new message sender methods.

Is the `type` property intentionally [optional in the `sendMessageToPeer` method](https://github.com/alexbosworth/lightning/blob/8df6f8a9918405801a7f7721ab9423eb9009e246/lnd_methods/offchain/send_message_to_peer.js#L28) while it's [required in the message received event](https://github.com/alexbosworth/lightning/blob/8df6f8a9918405801a7f7721ab9423eb9009e246/lnd_methods/offchain/subscribe_to_peer_messages.js#L33)? I think the types should be the same, or `type` has a default value in the received message object?


