### PR TITLE
Fix final page paging for 'getFailedPayments' and 'getPayments' methods

### DIFF
--- a/lnd_methods/offchain/get_failed_payments.js
+++ b/lnd_methods/offchain/get_failed_payments.js
@@ -8,7 +8,7 @@ const {sortBy} = require('./../../arrays');
 const defaultLimit = 250;
 const {isArray} = Array;
 const isFailed = payment => !!payment && payment.status === 'FAILED';
-const lastPageFirstIndexOffset = 0;
+const lastPageFirstIndexOffset = 1;
 const method = 'listPayments';
 const {parse} = JSON;
 const {stringify} = JSON;
@@ -152,7 +152,7 @@ module.exports = ({limit, lnd, token}, cbk) => {
 
           return cbk(null, {
             payments: res.payments.filter(isFailed),
-            token: offset === lastPageFirstIndexOffset ? undefined : token,
+            token: offset <= lastPageFirstIndexOffset ? undefined : token,
           });
         });
       }],

--- a/lnd_methods/offchain/get_payments.js
+++ b/lnd_methods/offchain/get_payments.js
@@ -157,7 +157,7 @@ module.exports = ({limit, lnd, token}, cbk) => {
 
           return cbk(null, {
             payments: res.payments,
-            token: offset === lastPageFirstIndexOffset ? undefined : token,
+            token: offset <= lastPageFirstIndexOffset ? undefined : token,
           });
         });
       }],

--- a/lnd_methods/offchain/get_payments.js
+++ b/lnd_methods/offchain/get_payments.js
@@ -185,7 +185,7 @@ module.exports = ({limit, lnd, token}, cbk) => {
         });
 
         return cbk(null, {
-          next: !!foundPayments.length ? listPayments.token : undefined,
+          next: listPayments.token || undefined,
           payments: payments.sorted.reverse(),
         });
       }],


### PR DESCRIPTION
### Description

Adjust the `lastPageFirstIndexOffset` value and check to be consistent across the 'getPayments' and 'getFailedPayments' methods since internally they both paginate in the exact same way. In both cases if there are payments present in the lnd then the last offset is `1`, but if there are no payments then the last offset is `0`.

Also noteworthy, when you go back with a token of `{"offset":1,"limit":250}` you would get 0 payments back for both methods, which confirms that a last offset of `1` works fine.

I also removed a redundant ternary check to make the returns for both methods consistent.