### PR TITLE
allow unconfirmed utxos in onchain fee estimates

### DIFF
--- a/lnd_methods/onchain/get_chain_fee_estimate.d.ts
+++ b/lnd_methods/onchain/get_chain_fee_estimate.d.ts
@@ -12,6 +12,8 @@ export type GetChainFeeEstimateArgs = AuthenticatedLightningArgs<{
   }[];
   /** Target Confirmations */
   target_confirmations?: number;
+  /** Minimum Confirmations for UTXO Selection */
+  utxo_confirmations?: number;
 }>;
 
 export type GetChainFeeEstimateResult = {

--- a/lnd_methods/onchain/get_chain_fee_estimate.js
+++ b/lnd_methods/onchain/get_chain_fee_estimate.js
@@ -8,6 +8,7 @@ const {isArray} = Array;
 const method = 'estimateFee';
 const notFound = -1;
 const type = 'default';
+const unconfirmedConfCount = 0;
 
 /** Get a chain fee estimate for a prospective chain send
 
@@ -20,6 +21,7 @@ const type = 'default';
       tokens: <Tokens Number>
     }]
     [target_confirmations]: <Target Confirmations Number>
+    [utxo_confirmations]: <Minimum Confirmations for UTXO Selection Number>
   }
 
   @returns via cbk or Promise
@@ -65,6 +67,8 @@ module.exports = (args, cbk) => {
         return args.lnd[type][method]({
           AddrToAmount,
           target_conf: args.target_confirmations || undefined,
+          min_confs: args.utxo_confirmations || undefined,
+          spend_unconfirmed: args.utxo_confirmations === unconfirmedConfCount,
         },
         (err, res) => {
           if (!!err) {


### PR DESCRIPTION
This pr follow the pattern from [sendToChainAddress](https://github.com/alexbosworth/lightning/blob/master/lnd_methods/onchain/send_to_chain_address.js) to allow fee estimation using unconfirmed utxos by optionally specifying the amount of utxo confirmations required for inclusion in fee estimation. It correlates to this [gRPC request](https://github.com/alexbosworth/lightning/blob/fde3f2d2e41f46e329a6bf57e8b703e9feaf7ca6/grpc/protos/lightning.proto#L1054).