### PR TITLE
Update types

### DIFF
--- a/lnd_methods/onchain/index.d.ts
+++ b/lnd_methods/onchain/index.d.ts
@@ -33,3 +33,4 @@ export * from './subscribe_to_chain_spend';
 export * from './subscribe_to_transactions';
 export * from './unlock_utxo';
 export * from './update_chain_transaction';
+export * from './verify_chain_address_message';

--- a/lnd_methods/onchain/index.d.ts
+++ b/lnd_methods/onchain/index.d.ts
@@ -24,6 +24,7 @@ export * from './request_chain_fee_increase';
 export * from './send_to_chain_address';
 export * from './send_to_chain_addresses';
 export * from './send_to_chain_output_scripts';
+export * from './sign_chain_address_message';
 export * from './set_autopilot';
 export * from './sign_psbt';
 export * from './subscribe_to_blocks';

--- a/lnd_methods/onchain/sign_chain_address_message.d.ts
+++ b/lnd_methods/onchain/sign_chain_address_message.d.ts
@@ -1,0 +1,30 @@
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
+
+export type SignChainAddressMessageArgs = AuthenticatedLightningArgs<{
+  /** Chain Address String */
+  address: string;
+  /** Message To Sign String */
+  message: string;
+}>;
+
+export type SignChainAddressMessageResult = {
+  /** Hex Encoded Signature String */
+  signature: string;
+};
+
+/**
+ * Sign a chain address message using ECDSA
+ *
+ * Note: this method is not supported in LND versions 0.15.5 and below
+ *
+ * Requires LND built with `walletrpc` tag
+ *
+ * `onchain:write` permission is required
+ */
+export const signChainAddressMessage: AuthenticatedLightningMethod<
+  SignChainAddressMessageArgs,
+  SignChainAddressMessageResult
+>;

--- a/lnd_methods/onchain/verify_chain_address_message.d.ts
+++ b/lnd_methods/onchain/verify_chain_address_message.d.ts
@@ -1,0 +1,32 @@
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
+
+export type VerifyChainAddressMessageArgs = AuthenticatedLightningArgs<{
+  /** Chain Address String */
+  address: string;
+  /** Message to Verify String */
+  message: string;
+  /** Hex Encoded Signature String */
+  signature: string;
+}>;
+
+export type VerifyChainAddressMessageResult = {
+  /** Public Key Hex String */
+  signed_by: string;
+};
+
+/**
+ * Verify a chain address message using ECDSA
+ *
+ * Note: this method is not supported in LND versions 0.15.5 and below
+ *
+ * Requires LND built with `walletrpc` tag
+ *
+ * `onchain:write` permission is required
+ */
+export const verifyChainAddressMessage: AuthenticatedLightningMethod<
+  VerifyChainAddressMessageArgs,
+  VerifyChainAddressMessageResult
+>;

--- a/test/typescript/authenticated_lightning_method.test-d.ts
+++ b/test/typescript/authenticated_lightning_method.test-d.ts
@@ -1,4 +1,4 @@
-import {expectError} from 'tsd';
+import {expectError, expectType} from 'tsd';
 import {AuthenticatedLnd} from '../../lnd_grpc';
 import {
   AuthenticatedLightningArgs,
@@ -15,4 +15,4 @@ const lnd = {} as AuthenticatedLnd;
 
 expectError(authenticatedLightningMethod());
 expectError(authenticatedLightningMethod({}));
-expectError(authenticatedLightningMethod({lnd}));
+expectType(authenticatedLightningMethod({lnd}));

--- a/test/typescript/authenticated_lightning_method.test-d.ts
+++ b/test/typescript/authenticated_lightning_method.test-d.ts
@@ -1,0 +1,18 @@
+import {expectError} from 'tsd';
+import {AuthenticatedLnd} from '../../lnd_grpc';
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
+
+type TestArgs = AuthenticatedLightningArgs;
+type TestResult = unknown;
+type TestMethod = AuthenticatedLightningMethod<TestArgs, TestResult>;
+
+const authenticatedLightningMethod: TestMethod = async () => {};
+
+const lnd = {} as AuthenticatedLnd;
+
+expectError(authenticatedLightningMethod());
+expectError(authenticatedLightningMethod({}));
+expectError(authenticatedLightningMethod({lnd}));

--- a/test/typescript/sign_chain_address_message.test-d.ts
+++ b/test/typescript/sign_chain_address_message.test-d.ts
@@ -1,0 +1,33 @@
+import {expectError, expectType} from 'tsd';
+import {AuthenticatedLnd} from '../../lnd_grpc';
+import {
+  signChainAddressMessage,
+  SignChainAddressMessageResult,
+} from '../../lnd_methods';
+
+const lnd = {} as AuthenticatedLnd;
+const address = '';
+const message = '';
+
+expectError(signChainAddressMessage());
+expectError(signChainAddressMessage({}));
+expectError(signChainAddressMessage({lnd}));
+expectError(signChainAddressMessage({address}));
+expectError(signChainAddressMessage({message}));
+expectError(signChainAddressMessage({lnd, address}));
+expectError(signChainAddressMessage({lnd, message}));
+expectError(signChainAddressMessage({address, message}));
+
+expectType<SignChainAddressMessageResult>(
+  await signChainAddressMessage({
+    lnd,
+    address,
+    message,
+  }),
+);
+
+expectType<void>(
+  signChainAddressMessage({lnd, address, message}, (error, result) => {
+    expectType<SignChainAddressMessageResult>(result);
+  }),
+);

--- a/test/typescript/sign_chain_address_message.test-d.ts
+++ b/test/typescript/sign_chain_address_message.test-d.ts
@@ -9,14 +9,8 @@ const lnd = {} as AuthenticatedLnd;
 const address = '';
 const message = '';
 
-expectError(signChainAddressMessage());
-expectError(signChainAddressMessage({}));
-expectError(signChainAddressMessage({lnd}));
-expectError(signChainAddressMessage({address}));
-expectError(signChainAddressMessage({message}));
 expectError(signChainAddressMessage({lnd, address}));
 expectError(signChainAddressMessage({lnd, message}));
-expectError(signChainAddressMessage({address, message}));
 
 expectType<SignChainAddressMessageResult>(
   await signChainAddressMessage({

--- a/test/typescript/verify_chain_address_message.test-d.ts
+++ b/test/typescript/verify_chain_address_message.test-d.ts
@@ -1,0 +1,32 @@
+import {expectError, expectType} from 'tsd';
+import {AuthenticatedLnd} from '../../lnd_grpc';
+import {
+  verifyChainAddressMessage,
+  VerifyChainAddressMessageResult,
+} from '../../lnd_methods';
+
+const lnd = {} as AuthenticatedLnd;
+const address = '';
+const message = '';
+const signature = '';
+
+expectError(verifyChainAddressMessage({lnd, address}));
+expectError(verifyChainAddressMessage({lnd, message}));
+expectError(verifyChainAddressMessage({lnd, address, message}));
+expectError(verifyChainAddressMessage({lnd, address, signature}));
+expectError(verifyChainAddressMessage({lnd, message, signature}));
+
+expectType<VerifyChainAddressMessageResult>(
+  await verifyChainAddressMessage({
+    lnd,
+    address,
+    message,
+    signature,
+  }),
+);
+
+expectType<void>(
+  verifyChainAddressMessage({lnd, address, message, signature}, (error, result) => {
+    expectType<VerifyChainAddressMessageResult>(result);
+  }),
+);


### PR DESCRIPTION
closes #128 and also added a generic test for authenticated lightning methods so missing `lnd` arg doesn't need to be tested for every method