### PR TITLE
Add id to failureFromPayment

### DIFF
--- a/lnd_responses/failure_from_payment.d.ts
+++ b/lnd_responses/failure_from_payment.d.ts
@@ -1,10 +1,13 @@
 import {FailureReason} from '../typescript';
 
 export type FailureFromPaymentArgs = {
+  payment_hash: string;
   failure_reason: FailureReason;
 };
 
 export type FailureFromPaymentResult = {
+  /** Payment Hash Hex String */
+  id: string;
   /** Payment Failed Due to Insufficient Balance Bool */
   is_insufficient_balance: boolean;
   /** Payment Failed Due to Invalid Details Rejection Bool */
@@ -16,32 +19,40 @@ export type FailureFromPaymentResult = {
 };
 
 export function failureFromPayment(payment: {
+  payment_hash: string,
   failure_reason: 'FAILURE_REASON_INSUFFICIENT_BALANCE';
 }): {
+  id: string,
   is_insufficient_balance: true;
   is_invalid_payment: false;
   is_pathfinding_timeout: false;
   is_route_not_found: false;
 };
 export function failureFromPayment(payment: {
+  payment_hash: string,
   failure_reason: 'FAILURE_REASON_INCORRECT_PAYMENT_DETAILS';
 }): {
+  id: string,
   is_insufficient_balance: false;
   is_invalid_payment: true;
   is_pathfinding_timeout: false;
   is_route_not_found: false;
 };
 export function failureFromPayment(payment: {
+  payment_hash: string,
   failure_reason: 'FAILURE_REASON_TIMEOUT';
 }): {
+  id: string,
   is_insufficient_balance: false;
   is_invalid_payment: false;
   is_pathfinding_timeout: true;
   is_route_not_found: false;
 };
 export function failureFromPayment(payment: {
+  payment_hash: string,
   failure_reason: 'FAILURE_REASON_NO_ROUTE';
 }): {
+  id: string,
   is_insufficient_balance: false;
   is_invalid_payment: false;
   is_pathfinding_timeout: false;

--- a/lnd_responses/failure_from_payment.js
+++ b/lnd_responses/failure_from_payment.js
@@ -1,13 +1,17 @@
 const {failureReason} = require('./constants');
 
+const is256Hex = n => !!n && /^[0-9A-F]{64}$/i.test(n);
+
 /** Derive failure status from payment
 
   {
+    payment_hash: <Payment SHA256 Hash Hex String>
     failure_reason: <Payment Failure Reason String>
   }
 
   @returns
   {
+     id: <Payment Hash Hex String>
      is_insufficient_balance: <Payment Failed Due to Insufficient Balance Bool>
      is_invalid_payment: <Payment Failed Due to Invalid Details Rejection Bool>
      is_pathfinding_timeout: <Failure Due To Pathfinding Timeout Failure Bool>
@@ -17,7 +21,12 @@ const {failureReason} = require('./constants');
 module.exports = payment => {
   const state = payment.failure_reason;
 
+  if (!is256Hex(payment.payment_hash)) {
+    throw new Error('ExpectedPaymentHashForPaymentAsFailedPayment');
+  }
+
   return {
+    id: payment.payment_hash,
     is_insufficient_balance: state === failureReason.insufficient_balance,
     is_invalid_payment: state === failureReason.invalid_payment,
     is_pathfinding_timeout: state === failureReason.pathfinding_timeout_failed,

--- a/test/lnd_responses/test_failure_from_payment.js
+++ b/test/lnd_responses/test_failure_from_payment.js
@@ -2,8 +2,11 @@ const {test} = require('@alexbosworth/tap');
 
 const {failureFromPayment} = require('./../../lnd_responses');
 
+const payment_hash = Buffer.alloc(32).toString('hex')
+
 const makeExpected = overrides => {
   const expected = {
+    id: payment_hash,
     is_insufficient_balance: false,
     is_invalid_payment: false,
     is_pathfinding_timeout: false,
@@ -17,24 +20,29 @@ const makeExpected = overrides => {
 
 const tests = [
   {
-    args: {failure_reason: 'FAILURE_REASON_INSUFFICIENT_BALANCE'},
+    args: {payment_hash, failure_reason: 'FAILURE_REASON_INSUFFICIENT_BALANCE'},
     description: 'Insufficient balance mapped',
     expected: makeExpected({is_insufficient_balance: true}),
   },
   {
-    args: {failure_reason: 'FAILURE_REASON_INCORRECT_PAYMENT_DETAILS'},
+    args: {payment_hash, failure_reason: 'FAILURE_REASON_INCORRECT_PAYMENT_DETAILS'},
     description: 'Invalid payment is mapped',
     expected: makeExpected({is_invalid_payment: true}),
   },
   {
-    args: {failure_reason: 'FAILURE_REASON_NO_ROUTE'},
+    args: {payment_hash, failure_reason: 'FAILURE_REASON_NO_ROUTE'},
     description: 'No route is mapped',
     expected: makeExpected({is_route_not_found: true}),
   },
   {
-    args: {failure_reason: 'FAILURE_REASON_TIMEOUT'},
+    args: {payment_hash, failure_reason: 'FAILURE_REASON_TIMEOUT'},
     description: 'Timeout is mapped',
     expected: makeExpected({is_pathfinding_timeout: true}),
+  },
+  {
+    args: {payment_hash: undefined},
+    description: 'A payment hash is expected',
+    error: 'ExpectedPaymentHashForPaymentAsFailedPayment',
   },
 ];
 

--- a/test/typescript/failure_from_payment.test-d.ts
+++ b/test/typescript/failure_from_payment.test-d.ts
@@ -1,41 +1,49 @@
 import {expectError, expectType} from 'tsd';
 import {failureFromPayment} from '../../lnd_responses/failure_from_payment';
 
+const payment_hash = Buffer.alloc(32).toString('hex')
+
 expectError(failureFromPayment());
 expectError(failureFromPayment({}));
-expectError(failureFromPayment({failure_reason: 'invalid failure reason'}));
+expectError(failureFromPayment({payment_hash, failure_reason: 'invalid failure reason'}));
 
 expectType<{
+  id: string;
   is_insufficient_balance: boolean;
   is_invalid_payment: boolean;
   is_pathfinding_timeout: boolean;
   is_route_not_found: boolean;
-}>(failureFromPayment({failure_reason: 'FAILURE_REASON_NONE'}));
+}>(failureFromPayment({payment_hash, failure_reason: 'FAILURE_REASON_NONE'}));
 expectType<{
+  id: string;
   is_insufficient_balance: true;
   is_invalid_payment: false;
   is_pathfinding_timeout: false;
   is_route_not_found: false;
-}>(failureFromPayment({failure_reason: 'FAILURE_REASON_INSUFFICIENT_BALANCE'}));
+}>(failureFromPayment({payment_hash, failure_reason: 'FAILURE_REASON_INSUFFICIENT_BALANCE'}));
 expectType<{
+  id: string;
   is_insufficient_balance: false;
   is_invalid_payment: true;
   is_pathfinding_timeout: false;
   is_route_not_found: false;
 }>(
   failureFromPayment({
+    payment_hash,
     failure_reason: 'FAILURE_REASON_INCORRECT_PAYMENT_DETAILS',
   })
 );
 expectType<{
+  id: string;
   is_insufficient_balance: false;
   is_invalid_payment: false;
   is_pathfinding_timeout: true;
   is_route_not_found: false;
-}>(failureFromPayment({failure_reason: 'FAILURE_REASON_TIMEOUT'}));
+}>(failureFromPayment({payment_hash, failure_reason: 'FAILURE_REASON_TIMEOUT'}));
 expectType<{
+  id: string;
   is_insufficient_balance: false;
   is_invalid_payment: false;
   is_pathfinding_timeout: false;
   is_route_not_found: true;
-}>(failureFromPayment({failure_reason: 'FAILURE_REASON_NO_ROUTE'}));
+}>(failureFromPayment({payment_hash, failure_reason: 'FAILURE_REASON_NO_ROUTE'}));


### PR DESCRIPTION
Add id to failureFromPayment because there is no way to identify a failed payment when subscribeToPayments is used.

Feel free to update it if I am missing something