### PR TITLE
add is_trusted_funding and commitment_type to openChannel method

### DIFF
--- a/lnd_methods/onchain/open_channel.d.ts
+++ b/lnd_methods/onchain/open_channel.d.ts
@@ -33,8 +33,6 @@ export type ChannelOpenOptions = {
   partner_socket?: string;
   /** Peer Should Avoid Waiting For Confirmation */
   is_trusted_funding?: boolean;
-  /** Channel Commitment Transaction Type */
-  commitment_type?: CommitmentType;
 };
 
 export type OpenChannelArgs = AuthenticatedLightningArgs<ChannelOpenOptions>;

--- a/lnd_methods/onchain/open_channel.d.ts
+++ b/lnd_methods/onchain/open_channel.d.ts
@@ -3,6 +3,8 @@ import {
   AuthenticatedLightningMethod,
 } from '../../typescript';
 
+export type CommitmentType = 'UNKNOWN_COMMITMENT_TYPE' | 'LEGACY' | 'STATIC_REMOTE_KEY' | 'ANCHORS' | 'SCRIPT_ENFORCED_LEASE'
+
 export type ChannelOpenOptions = {
   /** Routing Base Fee Millitokens Charged String */
   base_fee_mtokens?: string;
@@ -30,6 +32,10 @@ export type ChannelOpenOptions = {
   partner_csv_delay?: number;
   /** Peer Connection Host:Port */
   partner_socket?: string;
+  /** Peer Should Avoid Waiting For Confirmation */
+  is_trusted_funding?: boolean;
+  /** Channel Commitment Transaction Type */
+  commitment_type?: CommitmentType;
 };
 
 export type OpenChannelArgs = AuthenticatedLightningArgs<ChannelOpenOptions>;

--- a/lnd_methods/onchain/open_channel.d.ts
+++ b/lnd_methods/onchain/open_channel.d.ts
@@ -2,8 +2,7 @@ import {
   AuthenticatedLightningArgs,
   AuthenticatedLightningMethod,
 } from '../../typescript';
-
-export type CommitmentType = 'UNKNOWN_COMMITMENT_TYPE' | 'LEGACY' | 'STATIC_REMOTE_KEY' | 'ANCHORS' | 'SCRIPT_ENFORCED_LEASE'
+import { CommitmentType } from '../../typescript';
 
 export type ChannelOpenOptions = {
   /** Routing Base Fee Millitokens Charged String */

--- a/lnd_methods/onchain/open_channel.d.ts
+++ b/lnd_methods/onchain/open_channel.d.ts
@@ -2,7 +2,6 @@ import {
   AuthenticatedLightningArgs,
   AuthenticatedLightningMethod,
 } from '../../typescript';
-import { CommitmentType } from '../../typescript';
 
 export type ChannelOpenOptions = {
   /** Routing Base Fee Millitokens Charged String */

--- a/lnd_methods/onchain/open_channel.js
+++ b/lnd_methods/onchain/open_channel.js
@@ -11,25 +11,6 @@ const minChannelTokens = 20000;
 const method = 'openChannel';
 const type = 'default';
 
-function commitmentTypeToNumber(type) {
-  if (!type) {
-    return undefined
-  }
-  const upperCaseType = type.toUpperCase()
-  if (upperCaseType === 'UNKNOWN_COMMITMENT_TYPE') {
-    return 0
-  } else if (upperCaseType === 'LEGACY') {
-    return 1
-  } else if (upperCaseType === 'STATIC_REMOTE_KEY') {
-    return 2
-  } else if (upperCaseType === 'ANCHORS') {
-    return 3
-  } else if (upperCaseType === 'SCRIPT_ENFORCED_LEASE') {
-    return 4
-  } else {
-    throw new Error(`Unknown commitment type ${type} not recognized.`)
-  }
-}
 
 /** Open a new channel.
 
@@ -138,7 +119,7 @@ module.exports = (args, cbk) => {
           use_base_fee: args.base_fee_mtokens !== undefined,
           use_fee_rate: args.fee_rate !== undefined,
           zero_conf: !!args.is_trusted_funding,
-          commitment_type: commitmentTypeToNumber(args.commitment_type),
+          commitment_type: !!args.is_trusted_funding? 3 :undefined, // Anchors
         };
 
         if (!!args.chain_fee_tokens_per_vbyte) {

--- a/lnd_methods/onchain/open_channel.js
+++ b/lnd_methods/onchain/open_channel.js
@@ -124,7 +124,7 @@ module.exports = (args, cbk) => {
           use_base_fee: args.base_fee_mtokens !== undefined,
           use_fee_rate: args.fee_rate !== undefined,
           zero_conf: !!args.is_trusted_funding,
-          commitment_type: !!args.is_trusted_funding? 3 :undefined, // Anchors
+          commitment_type: !!args.is_trusted_funding? 'ANCHORS' : undefined, // Anchors
         };
 
         if (!!args.chain_fee_tokens_per_vbyte) {

--- a/lnd_methods/onchain/open_channel.js
+++ b/lnd_methods/onchain/open_channel.js
@@ -29,6 +29,10 @@ const type = 'default';
 
   `description` is not supported on LND 0.16.4 and below
 
+  `is_trusted_funding` is not supported on LND 0.15.0 and below and requires
+  `--protocol.option-scid-alias` and `--protocol.zero-conf` set on both sides
+  as well as a channel open request listener to accept the trusted funding.
+
   {
     [base_fee_mtokens]: <Routing Base Fee Millitokens Charged String>
     [chain_fee_tokens_per_vbyte]: <Chain Fee Tokens Per VByte Number>

--- a/lnd_methods/onchain/open_channel.js
+++ b/lnd_methods/onchain/open_channel.js
@@ -11,6 +11,26 @@ const minChannelTokens = 20000;
 const method = 'openChannel';
 const type = 'default';
 
+function commitmentTypeToNumber(type) {
+  if (!type) {
+    return undefined
+  }
+  const upperCaseType = type.toUpperCase()
+  if (upperCaseType === 'UNKNOWN_COMMITMENT_TYPE') {
+    return 0
+  } else if (upperCaseType === 'LEGACY') {
+    return 1
+  } else if (upperCaseType === 'STATIC_REMOTE_KEY') {
+    return 2
+  } else if (upperCaseType === 'ANCHORS') {
+    return 3
+  } else if (upperCaseType === 'SCRIPT_ENFORCED_LEASE') {
+    return 4
+  } else {
+    throw new Error(`Unknown commitment type ${type} not recognized.`)
+  }
+}
+
 /** Open a new channel.
 
   The capacity of the channel is set with local_tokens
@@ -117,6 +137,8 @@ module.exports = (args, cbk) => {
           spend_unconfirmed: !minConfs,
           use_base_fee: args.base_fee_mtokens !== undefined,
           use_fee_rate: args.fee_rate !== undefined,
+          zero_conf: !!args.is_trusted_funding,
+          commitment_type: commitmentTypeToNumber(args.commitment_type),
         };
 
         if (!!args.chain_fee_tokens_per_vbyte) {

--- a/lnd_methods/onchain/open_channel.js
+++ b/lnd_methods/onchain/open_channel.js
@@ -45,6 +45,7 @@ const type = 'default';
     [partner_csv_delay]: <Peer Output CSV Delay Number>
     partner_public_key: <Public Key Hex String>
     [partner_socket]: <Peer Connection Host:Port String>
+    [is_trusted_funding]: <Accept Funding as Trusted Bool>
   }
 
   @returns via cbk or Promise


### PR DESCRIPTION
- Adds `is_trusted_funding` and `commitment_type` to openChannel method.
- Adds typescript type accordingly.

Usage:

```typescript
await ln.openChannel({
      lnd: lnd,
      local_tokens:
          localBalanceSat,
      partner_public_key: pubkey,
      is_private: isPrivate,
      is_trusted_funding: true,
      commitment_type: "ANCHORS"
  })
```

Let me know if you want to have anything changed. See #140 for more info.