### PR TITLE
Add zero_reserve argument to open_channel

### DIFF
--- a/lnd_methods/onchain/open_channel.d.ts
+++ b/lnd_methods/onchain/open_channel.d.ts
@@ -44,6 +44,8 @@ export type ChannelOpenOptions = {
   partner_public_key: string;
   /** Peer Connection Host:Port */
   partner_socket?: string;
+  /** Allow peer to have a minimal channel reserve (dust limit) */
+  is_allowing_minimal_reserve?: boolean;
 };
 
 export type OpenChannelArgs = AuthenticatedLightningArgs<ChannelOpenOptions>;

--- a/lnd_methods/onchain/open_channel.js
+++ b/lnd_methods/onchain/open_channel.js
@@ -13,6 +13,7 @@ const minChannelTokens = 20000;
 const method = 'openChannel';
 const simplifiedTaprootChannelType = 'SIMPLE_TAPROOT';
 const type = 'default';
+const static_dust_limit = 354;
 
 /** Open a new channel.
 
@@ -62,6 +63,7 @@ const type = 'default';
     [partner_csv_delay]: <Peer Output CSV Delay Number>
     partner_public_key: <Public Key Hex String>
     [partner_socket]: <Peer Connection Host:Port String>
+    [is_allowing_minimal_reserve]: <Allow peer to have a minimal channel reserve (dust limit) Bool>
   }
 
   @returns via cbk or Promise
@@ -162,6 +164,7 @@ module.exports = (args, cbk) => {
           use_base_fee: args.base_fee_mtokens !== undefined,
           use_fee_rate: args.fee_rate !== undefined,
           zero_conf: !!args.is_trusted_funding || undefined,
+          remote_chan_reserve_sat: args.is_allowing_minimal_reserve? static_dust_limit: undefined
         };
 
         if (!!args.chain_fee_tokens_per_vbyte) {


### PR DESCRIPTION
This PR adds the ability to open channels with zero remote channel reserve requirements. Zero in this context means the static dust limit of 354sat.

I tested it on regtest and it worked. I couldn't test it in a higher fee environment as I am not sure how I can increase the fee rate in regtest. Happy to do so if you can point me to how.

Let me know if you want anything changed. Thx.