### PR TITLE
update types

### DIFF
--- a/lnd_methods/onchain/delete_chain_transaction.d.ts
+++ b/lnd_methods/onchain/delete_chain_transaction.d.ts
@@ -1,0 +1,19 @@
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
+
+export type DeleteChainTransactionArgs = AuthenticatedLightningArgs<{
+  /** Transaction Id Hex String */
+  id: string;
+}>;
+
+/**
+ *
+ * Remove a chain transaction.
+ *
+ * Requires `onchain:write` permission
+ *
+ * This method is not supported on LND 0.17.3 and below
+ */
+export const deleteChainTransaction: AuthenticatedLightningMethod<DeleteChainTransactionArgs>;

--- a/lnd_methods/onchain/get_chain_transaction.d.ts
+++ b/lnd_methods/onchain/get_chain_transaction.d.ts
@@ -1,0 +1,24 @@
+import {
+  AuthenticatedLightningArgs,
+  AuthenticatedLightningMethod,
+} from '../../typescript';
+import {ChainTransaction} from './get_chain_transactions';
+
+export type GetChainTransactionArgs = AuthenticatedLightningArgs<{
+  /** Transaction Id Hex String */
+  id: string;
+}>;
+
+export type GetChainTransactionResult = ChainTransaction;
+
+/**
+ * Get a chain transaction.
+ *
+ * Requires `onchain:read` permission
+ *
+ * This method is not supported on LND 0.17.3 and below
+ */
+export const getChainTransaction: AuthenticatedLightningMethod<
+  GetChainTransactionArgs,
+  GetChainTransactionResult
+>;

--- a/lnd_methods/onchain/index.d.ts
+++ b/lnd_methods/onchain/index.d.ts
@@ -10,6 +10,7 @@ export * from './get_chain_addresses';
 export * from './get_chain_balance';
 export * from './get_chain_fee_estimate';
 export * from './get_chain_fee_rate';
+export * from './get_chain_transaction';
 export * from './get_chain_transactions';
 export * from './get_locked_utxos';
 export * from './get_master_public_keys';

--- a/lnd_methods/onchain/index.d.ts
+++ b/lnd_methods/onchain/index.d.ts
@@ -1,6 +1,7 @@
 export * from './broadcast_chain_transaction';
 export * from './cancel_pending_channel';
 export * from './close_channel';
+export * from './delete_chain_transaction';
 export * from './fund_pending_channels';
 export * from './fund_psbt';
 export * from './get_block';


### PR DESCRIPTION
Closes #153

tests are failing because of an unrelated issue with `subscribe_to_probe_for_route` on `master`