### PR TITLE
Add fields for `PayViaRoutesArgs`

### DIFF
--- a/lnd_methods/offchain/pay_via_routes.d.ts
+++ b/lnd_methods/offchain/pay_via_routes.d.ts
@@ -46,10 +46,14 @@ export type PayViaRoutesArgs = AuthenticatedLightningArgs<{
     }[];
     /** Total Millitokens To Pay */
     mtokens: string;
+    /** Payment Identifier Hex */
+    payment?: string;
     /** Expiration Block Height */
     timeout: number;
     /** Total Tokens To Pay */
     tokens: number;
+    /** Total Millitokens */
+    total_mtokens?: string;
   }[];
 }>;
 


### PR DESCRIPTION
I found that some field are being used when trying to pay a route, but were not in the TypeScript definition.

https://github.com/alexbosworth/lightning/blob/f8cc5d22c8251b5026d2d059275335439164cf24/lnd_requests/rpc_route_from_route.js#L78-L86