### PR TITLE
Fix undefined onchain fee in transaction RPC

### DIFF
--- a/lnd_responses/rpc_tx_as_transaction.js
+++ b/lnd_responses/rpc_tx_as_transaction.js
@@ -133,7 +133,7 @@ module.exports = tx => {
     confirmation_height: tx.block_height || undefined,
     created_at: new Date(Number(tx.time_stamp) * msPerSec).toISOString(),
     description: tx.label || undefined,
-    fee: Number(tx.total_fees) || undefined,
+    fee: Number(tx.total_fees) ?? undefined,
     id: tx.tx_hash,
     inputs: inputs.filter(n => !!n),
     is_confirmed: !!tx.num_confirmations,


### PR DESCRIPTION
It can be that the onchain fee (`total_fees`) is `0`. `||` sees that as a falsely value so `Number(tx.total_fees) || undefined` will result in `undefined`. Using `??`, it will stay `0`