### PR TITLE
Add is_allowing_minimal_reserve param to OpenChannels

### DIFF
--- a/lnd_methods/onchain/open_channels.d.ts
+++ b/lnd_methods/onchain/open_channels.d.ts
@@ -11,6 +11,7 @@ export type MultipleChannelOpenOptions = Pick<
   | 'description'
   | 'fee_rate'
   | 'give_tokens'
+  | 'is_allowing_minimal_reserve'
   | 'is_private'
   | 'min_htlc_mtokens'
   | 'partner_public_key'

--- a/lnd_methods/onchain/open_channels.js
+++ b/lnd_methods/onchain/open_channels.js
@@ -17,7 +17,7 @@ const {isArray} = Array;
 const isPublicKey = n => /^[0-9A-F]{66}$/i.test(n);
 const makeId = () => randomBytes(32);
 const method = 'openChannel';
-const notEnoughOutputs = 'not enough witness outputs to create funding';
+const reserve = isDust => isDust ? 354 : undefined;
 const taproot = 'SIMPLE_TAPROOT';
 const type = 'default';
 
@@ -38,6 +38,8 @@ const type = 'default';
   `--protocol.option-scid-alias` and `--protocol.zero-conf` set on both sides
   as well as a channel open request listener to accept the trusted funding.
 
+  `is_allowing_minimal_reserve` is not supported on LND 0.15.0 and below
+
   `base_fee_mtokens` is not supported on LND 0.15.5 and below
   `fee_rate` is not supported on LND 0.15.5 and below
 
@@ -54,6 +56,7 @@ const type = 'default';
       [description]: <Immutable Channel Description String>
       [fee_rate]: <Routing Fee Rate In Millitokens Per Million Number>
       [give_tokens]: <Tokens to Gift To Partner Number> // Defaults to zero
+      [is_allowing_minimal_reserve]: <Allow Peer to Have Minimal Reserve Bool>
       [is_private]: <Channel is Private Bool> // Defaults to false
       [is_simplified_taproot]: <Channel is Simplified Taproot Type Bool>
       [is_trusted_funding]: <Peer Should Avoid Waiting For Confirmation Bool>
@@ -113,6 +116,7 @@ module.exports = (args, cbk) => {
           cooperative_close_address: channel.cooperative_close_address,
           give_tokens: channel.give_tokens,
           is_private: channel.is_private,
+          is_allowing_minimal_reserve: channel.is_allowing_minimal_reserve,
           is_simplified_taproot: channel.is_simplified_taproot,
           is_trusted_funding: channel.is_trusted_funding,
           min_htlc_mtokens: channel.min_htlc_mtokens,
@@ -148,6 +152,7 @@ module.exports = (args, cbk) => {
             min_htlc_msat: channel.min_htlc_mtokens || defaultMinHtlcMtokens,
             node_pubkey: bufferFromHex(channel.partner_public_key),
             private: !!channel.is_private,
+            remote_chan_reserve_sat: reserve(!!channel.is_allowing_minimal_reserve),
             push_sat: channel.give_tokens || undefined,
             remote_csv_delay: channel.partner_csv_delay || undefined,
             scid_alias: channel.is_trusted_funding && channel.is_private,


### PR DESCRIPTION
This is groundwork that will allow us to do trusted opens in `bos` with minimal channel reserves