### PR TITLE
Add partner_scid_alias to         getChannels type definitions

### DIFF
--- a/lnd_methods/offchain/get_channels.d.ts
+++ b/lnd_methods/offchain/get_channels.d.ts
@@ -60,6 +60,8 @@ export type GetChannelsResult = {
     local_reserve: number;
     /** Other Channel Ids */
     other_ids: string[];
+    /** Peer Assigned Standard Format Channel Id */
+    partner_scid_alias?: string;
     /** Channel Partner Public Key */
     partner_public_key: string;
     /** Past Channel States Count */

--- a/lnd_responses/rpc_channel_as_channel.js
+++ b/lnd_responses/rpc_channel_as_channel.js
@@ -61,6 +61,7 @@ const outpointDelimiter = ':';
     total_satoshis_received: <Total Tokens Transferred Inbound String>
     total_satoshis_sent: <Total Tokens Transferred Outbound String>
     unsettled_balance: <Balance In Transaction Tokens String>
+    [peer_scid_alias]: <Peer Assigned Channel Id Number String>
     uptime: <Channel Internal Monitoring Channel Active Seconds Number>
     zero_conf_confirmed_scid: <Trusted Channel Confirmed Id Number String>
   }
@@ -92,6 +93,7 @@ const outpointDelimiter = ':';
     local_min_htlc_mtokens: <Local Minimum HTLC Millitokens String>
     local_reserve: <Local Reserved Tokens Number>
     other_ids: [<Other Channel Id String>]
+    [partner_scid_alias]: <Peer Assigned Standard Format Channel Id String>
     partner_public_key: <Channel Partner Public Key String>
     past_states: <Total Count of Past States Number>
     pending_payments: [{
@@ -256,6 +258,9 @@ module.exports = args => {
     local_min_htlc_mtokens: own.min_htlc_msat,
     local_reserve: Number(own.chan_reserve_sat),
     other_ids: otherIds.map(n => n.channel),
+    partner_scid_alias: args.peer_scid_alias
+      ? chanFormat({number: args.peer_scid_alias}).channel
+      : undefined,
     partner_public_key: args.remote_pubkey,
     past_states: Number(args.num_updates),
     pending_payments: args.pending_htlcs.map(rpcHtlcAsPayment),

--- a/test/lnd_methods/offchain/test_get_channels.js
+++ b/test/lnd_methods/offchain/test_get_channels.js
@@ -28,6 +28,7 @@ const makeExpected = overrides => {
     local_max_pending_mtokens: '1',
     local_reserve: 1,
     other_ids: [],
+    partner_scid_alias: undefined,
     partner_public_key: 'b',
     past_states: 1,
     pending_payments: [{

--- a/test/lnd_methods/offchain/test_subscribe_to_channels.js
+++ b/test/lnd_methods/offchain/test_subscribe_to_channels.js
@@ -263,6 +263,7 @@ const tests = [
             local_min_htlc_mtokens: '1',
             local_reserve: 1,
             other_ids: [],
+            partner_scid_alias: undefined,
             partner_public_key: '000000000000000000000000000000000000000000000000000000000000000000',
             past_states: 1,
             pending_payments: [],

--- a/test/lnd_responses/test_rpc_channel_as_channel.js
+++ b/test/lnd_responses/test_rpc_channel_as_channel.js
@@ -87,6 +87,7 @@ const makeExpected = overrides => {
     local_min_htlc_mtokens: '1',
     local_reserve: 1,
     other_ids: [],
+    partner_scid_alias: undefined,
     partner_public_key: '00',
     past_states: 1,
     pending_payments: [{
@@ -249,6 +250,11 @@ const tests = [
     args: makeArgs({alias_scids: ['2', '3'], zero_conf_confirmed_scid: '2'}),
     description: 'RPC channel is mapped to channel with scids',
     expected: makeExpected({id: '0x0x2', other_ids: ['0x0x3']}),
+  },
+  {
+    args: makeArgs({peer_scid_alias: '4'}),
+    description: 'RPC channel is mapped to channel with peer scid alias',
+    expected: makeExpected({partner_scid_alias: '0x0x4'}),
   },
   {
     args: makeArgs({commitment_type: 'ANCHORS', initiator: true}),


### PR DESCRIPTION
Adds the missing partner_scid_alias field.