### PR TITLE
Allow zero accept height and time in invoice HTLC

### DIFF
--- a/lnd_responses/htlc_as_payment.js
+++ b/lnd_responses/htlc_as_payment.js
@@ -50,11 +50,11 @@ const mtokensPerToken = BigInt(1e3);
   }
 */
 module.exports = args => {
-  if (!args.accept_height) {
+  if (args.accept_height === undefined) {
     throw new Error('ExpectedAcceptHeightInResponseHtlc');
   }
 
-  if (!args.accept_time) {
+  if (args.accept_time === undefined) {
     throw new Error('ExpectedAcceptTimeInResponseHtlc');
   }
 

--- a/test/lnd_responses/test_htlc_as_payment.js
+++ b/test/lnd_responses/test_htlc_as_payment.js
@@ -111,6 +111,26 @@ const tests = [
     },
   },
   {
+    args: makeHtlc({accept_height: 0, accept_time: '0', state: 'CANCELED'}),
+    description: 'Never accepted HTLC mapped to payment',
+    expected: {
+      canceled_at: '1970-01-01T00:00:01.000Z',
+      confirmed_at: undefined,
+      created_at: '1970-01-01T00:00:00.000Z',
+      created_height: 0,
+      in_channel: '0x0x1',
+      is_canceled: true,
+      is_confirmed: false,
+      is_held: false,
+      messages: [{type: '16', value: '01'}],
+      mtokens: '1',
+      pending_index: undefined,
+      timeout: 1,
+      tokens: 0,
+      total_mtokens: undefined,
+    },
+  },
+  {
     args: makeHtlc({mpp_total_amt_msat: '1', state: 'ACCEPTED'}),
     description: 'Accepted HTLC mapped to payment',
     expected: {


### PR DESCRIPTION
LND reports `accept_height: 0` for invoice HTLCs that were never accepted. Since protos are loaded with `defaults: true`, the field is always present as a number and the truthiness check rejects the `0` value, throwing `ExpectedAcceptHeightInResponseHtlc` and ending the `subscribeToInvoices` subscription on every replay of the invoice.

Check for `undefined` instead, matching the existing `resolve_time` check.

Fixes #211