### PR TITLE
Treat a zero peer scid alias as no alias in getChannels

### DIFF
--- a/lnd_responses/rpc_channel_as_channel.js
+++ b/lnd_responses/rpc_channel_as_channel.js
@@ -259,7 +259,7 @@ module.exports = args => {
     local_min_htlc_mtokens: own.min_htlc_msat,
     local_reserve: Number(own.chan_reserve_sat),
     other_ids: otherIds.map(n => n.channel),
-    partner_scid_alias: args.peer_scid_alias
+    partner_scid_alias: !!Number(args.peer_scid_alias)
       ? chanFormat({number: args.peer_scid_alias}).channel
       : undefined,
     partner_public_key: args.remote_pubkey,

--- a/test/lnd_responses/test_rpc_channel_as_channel.js
+++ b/test/lnd_responses/test_rpc_channel_as_channel.js
@@ -257,6 +257,11 @@ const tests = [
     expected: makeExpected({partner_scid_alias: '0x0x4'}),
   },
   {
+    args: makeArgs({peer_scid_alias: '0'}),
+    description: 'A zero peer scid alias is treated as no alias',
+    expected: makeExpected({partner_scid_alias: undefined}),
+  },
+  {
     args: makeArgs({commitment_type: 'ANCHORS', initiator: true}),
     description: 'Initiated RPC channel is mapped to channel',
     expected: makeExpected({


### PR DESCRIPTION
## Summary

`getChannels` returns `partner_scid_alias: '0x0x0'` for channels that have **no** peer SCID alias, instead of `undefined`.

## Root cause

`peer_scid_alias` is a `uint64` declared with `[jstype = JS_STRING]`, so a channel with no peer alias comes across the wire as the **string `'0'`**. In `lnd_responses/rpc_channel_as_channel.js` the guard tests that value for truthiness directly:

```js
partner_scid_alias: args.peer_scid_alias
  ? chanFormat({number: args.peer_scid_alias}).channel
  : undefined,
```

The string `'0'` is **truthy**, so instead of short-circuiting to `undefined` it is formatted through `chanFormat` to the string `'0x0x0'`.

Notably the `zero_conf_confirmed_scid` handling a few lines above already guards the *same* JS_STRING-zero case correctly:

```js
const channelId = !!Number(zeroConfRealId) ? zeroConfRealId : args.chan_id;
```

`peer_scid_alias` just missed the `!!Number(...)` coercion.

## Fix

```diff
-    partner_scid_alias: args.peer_scid_alias
+    partner_scid_alias: !!Number(args.peer_scid_alias)
       ? chanFormat({number: args.peer_scid_alias}).channel
       : undefined,
```

One-line change mirroring the existing `zero_conf_confirmed_scid` guard. Added a test: `peer_scid_alias: '0'` → `partner_scid_alias: undefined`.

## Why it matters

A common pattern for building a private-channel route hint is to prefer the peer alias and fall back to the real channel id:

```js
channel: channel.partner_scid_alias ?? channel.id
```

Because the sentinel was the non-nullish string `'0x0x0'` rather than `undefined`, `??` never fell back — so channels without a peer alias (e.g. a confirmed private channel) produced an **unroutable `0x0x0`** short channel id in the hint, even though the channel had a perfectly valid real scid. Returning `undefined` for "no alias" restores the expected `??` behavior.

## Testing

- `test/lnd_responses/test_rpc_channel_as_channel.js`: 29/29 pass with the fix.
- The new case fails on `master` (produces `partner_scid_alias: '0x0x0'`), passes after the change.